### PR TITLE
Improve session UX and history display

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -119,6 +119,7 @@
                                 <div id="connectionDot" class="w-2 h-2 bg-green-400 rounded-full animate-ping-slow"></div>
                                 <span id="connectionText" class="text-xs font-medium text-white">Connected</span>
                             </div>
+                            <p class="text-white/90 text-sm">Elapsed: <span id="timeElapsed">0:00</span></p>
                         </div>
                     </div>
                 </div>
@@ -260,10 +261,24 @@
     const socket = io();
     let sessionCode = null;
     const groups = new Map();
+    let elapsedInterval = null;
+    let recordingStart = null;
     let heartbeatInterval = null;
     let connectionCheckInterval = null;
     let lastHeartbeatTime = Date.now();
     let isConnected = true;
+
+    function resetUI() {
+        groups.clear();
+        document.getElementById('groupsGrid').innerHTML = '';
+        document.getElementById('groupsGrid').classList.add('hidden');
+        document.getElementById('emptyState').classList.remove('hidden');
+        document.getElementById('timeElapsed').textContent = '0:00';
+        if (elapsedInterval) {
+            clearInterval(elapsedInterval);
+            elapsedInterval = null;
+        }
+    }
     
     // Error handling
     function showErrorToast(message) {
@@ -875,8 +890,11 @@
         updateGroup(group, { isActive: true });
         
         // Fetch existing data for this group
-        fetch(`/api/session/${sessionCode}/group/${group}/transcripts`)
-            .then(res => res.json())
+        fetch(`/api/transcripts/${sessionCode}/${group}`)
+            .then(async res => {
+                if (!res.ok) return { transcripts: [], summary: null, stats: {} };
+                return res.json();
+            })
             .then(data => {
                 // Format existing transcripts with proper structure
                 const formattedTranscripts = data.transcripts.map(t => ({
@@ -940,6 +958,11 @@
             isActive: true
         });
     });
+
+    socket.on('session_reset', () => {
+        console.log('Session reset received');
+        resetUI();
+    });
     
     // Heartbeat and connection event handlers
     socket.on('admin_heartbeat_ack', () => {
@@ -1000,7 +1023,17 @@
             // Disable interval input while recording
             document.getElementById('intervalInput').disabled = true;
             document.getElementById('intervalInput').classList.add('opacity-50', 'cursor-not-allowed');
-            
+
+            recordingStart = Date.now();
+            elapsedInterval = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - recordingStart) / 1000);
+                const m = Math.floor(elapsed / 60);
+                const s = elapsed % 60;
+                document.getElementById('timeElapsed').textContent = `${m}:${s.toString().padStart(2,'0')}`;
+            }, 1000);
+
+            resetUI();
+
             showTemporaryMessage('Recording started successfully!', 'success');
         } catch (err) {
             console.error('Failed to start session:', err);
@@ -1024,7 +1057,12 @@
             // Re-enable interval input
             document.getElementById('intervalInput').disabled = false;
             document.getElementById('intervalInput').classList.remove('opacity-50', 'cursor-not-allowed');
-            
+
+            if (elapsedInterval) {
+                clearInterval(elapsedInterval);
+                elapsedInterval = null;
+            }
+            document.getElementById('timeElapsed').textContent = '0:00';
             showTemporaryMessage('Recording stopped successfully!', 'success');
         } catch (err) {
             console.error('Failed to stop session:', err);

--- a/public/student.html
+++ b/public/student.html
@@ -90,7 +90,7 @@
                                     <span id="connectionText" class="text-xs font-medium text-white/90">Connected</span>
                                 </div>
                             </h1>
-                            <p class="text-white/80 text-sm">Session: <span id="activeSession" class="font-mono">-</span> | Group: <span id="activeGroup">-</span></p>
+                            <p class="text-white/80 text-sm">Session: <span id="activeSession" class="font-mono">-</span> | Group: <span id="activeGroup">-</span> | Elapsed: <span id="timeElapsed">0:00</span></p>
                         </div>
                     </div>
                     <div class="flex items-center space-x-4">
@@ -202,6 +202,20 @@
         let lastHeartbeatTime = Date.now();
         let isConnected = true;
         let hasJoinedSession = false;
+        let elapsedInterval = null;
+        let recordingStart = null;
+
+        function resetView() {
+            document.getElementById('latestTranscript').innerHTML = '';
+            document.getElementById('olderTranscripts').innerHTML = '';
+            summaryArea.innerHTML = '';
+            summaryTimestamp.classList.add('hidden');
+            document.getElementById('timeElapsed').textContent = '0:00';
+            if (elapsedInterval) {
+                clearInterval(elapsedInterval);
+                elapsedInterval = null;
+            }
+        }
         
         // Initialize Lucide icons
         document.addEventListener('DOMContentLoaded', () => {
@@ -329,8 +343,8 @@
         async function startRecording() {
             try {
                 console.log("🎤 Starting recording...");
-                
-                stream = await navigator.mediaDevices.getUserMedia({ 
+
+                stream = await navigator.mediaDevices.getUserMedia({
                     audio: {
                         echoCancellation: true,
                         noiseSuppression: true,
@@ -340,7 +354,17 @@
                 
                 isRecording = true;
                 updateStatus(isPageVisible ? "Recording..." : "Recording in background...", "recording");
-                
+
+                recordingStart = Date.now();
+                elapsedInterval = setInterval(() => {
+                    const elapsed = Math.floor((Date.now() - recordingStart) / 1000);
+                    const m = Math.floor(elapsed / 60);
+                    const s = elapsed % 60;
+                    document.getElementById('timeElapsed').textContent = `${m}:${s.toString().padStart(2,'0')}`;
+                }, 1000);
+
+                resetView();
+
                 // Start the first recording cycle
                 startRecordingCycle();
                 
@@ -552,6 +576,12 @@
                 if (mediaRecorder && mediaRecorder.state === 'recording') {
                     mediaRecorder.stop();
                 }
+
+                if (elapsedInterval) {
+                    clearInterval(elapsedInterval);
+                    elapsedInterval = null;
+                }
+                document.getElementById('timeElapsed').textContent = '0:00';
                 
                 // Stop the stream
                 if (stream) {
@@ -756,6 +786,11 @@
         socket.on('stop_recording', () => {
             console.log(`🛑 Session stopped recording${isPageVisible ? '' : ' [BACKGROUND]'}`);
             stopRecording();
+        });
+
+        socket.on('session_reset', () => {
+            console.log('Session reset received');
+            resetView();
         });
 
         socket.on('transcription_and_summary', (data) => {


### PR DESCRIPTION
## Summary
- reset clients when starting a new recording
- allow saving prompts before recording starts
- display full transcripts in history
- show elapsed time while recording
- handle missing group data without errors
- clean up timers on stop
- improve duration formatting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875084eb01c8327a2cc54dd4ba9460c