### PR TITLE
Improve error messages on History page

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -185,6 +185,10 @@
                 });
 
                 const response = await fetch(`/api/history?${params}`);
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(text || `HTTP ${response.status}`);
+                }
                 const data = await response.json();
 
                 displaySessions(data);
@@ -371,6 +375,10 @@
 
             try {
                 const response = await fetch(`/api/history/session/${sessionCode}`);
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(text || `HTTP ${response.status}`);
+                }
                 const data = await response.json();
                 
                 content.innerHTML = `
@@ -677,6 +685,10 @@ This action cannot be undone.`;
                     })
                 });
 
+                if (!response.ok) {
+                    const text = await response.text();
+                    throw new Error(text || `HTTP ${response.status}`);
+                }
                 const result = await response.json();
 
                 if (response.ok) {


### PR DESCRIPTION
## Summary
- handle HTTP errors when fetching history and session details
- add similar error handling when deleting sessions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875b170bb108327aedb5c4831e1f594