### PR TITLE
Add static admin page and prompt library

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ app.get("/admin", (req, res) => {
   console.log("👨‍🏫 Serving admin page");
   res.sendFile(path.join(__dirname, "public", "admin.html"));
 });
+app.get("/admin_static", (req, res) => {
+  console.log("👨‍🏫 Serving static admin page");
+  res.sendFile(path.join(__dirname, "public", "admin_static.html"));
+});
 
 /* Serve test transcription page */
 app.get("/test-transcription", (req, res) => {
@@ -276,7 +280,7 @@ app.get("/api/session/:code/prompt", async (req, res) => {
 app.get("/api/new-session", async (req, res) => {
   try {
     const id = uuid();
-    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    const code = req.query.code || Math.floor(100000 + Math.random() * 900000).toString();
     const interval = Number(req.query.interval) || 30000;
     
     // Clear any existing session with same code (unlikely but safe)

--- a/public/admin_static.html
+++ b/public/admin_static.html
@@ -425,8 +425,10 @@
     // Default prompt
     const DEFAULT_PROMPT = "Summarise the following classroom discussion in ≤6 clear bullet points:";
     
-    // Create new session on page load
-    fetch('/api/new-session')
+    // Create or join static session on page load
+    const urlParams = new URLSearchParams(window.location.search);
+    sessionCode = urlParams.get('code') || '123456';
+    fetch(`/api/new-session?code=${sessionCode}`)
         .then(res => res.json())
         .then(data => {
             sessionCode = data.code;

--- a/public/student.html
+++ b/public/student.html
@@ -205,6 +205,16 @@
         let elapsedInterval = null;
         let recordingStart = null;
 
+        // Auto join if URL parameters provided
+        const params = new URLSearchParams(window.location.search);
+        const presetCode = params.get('code');
+        const presetGroup = params.get('group');
+        if (presetCode) document.getElementById('sessionCode').value = presetCode;
+        if (presetGroup) document.getElementById('groupNumber').value = presetGroup;
+        if (presetCode && presetGroup) {
+            document.getElementById('joinSessionForm').dispatchEvent(new Event('submit'));
+        }
+
         function resetView() {
             document.getElementById('latestTranscript').innerHTML = '';
             document.getElementById('olderTranscripts').innerHTML = '';


### PR DESCRIPTION
## Summary
- support specifying session code for `/api/new-session`
- serve new `/admin_static` page
- auto join student page from `code` and `group` query params
- allow saving prompts to a library in local storage
- add new static admin page using fixed code

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687636a78c44832795c8d191be1f1719